### PR TITLE
chore: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Run lint
+        run: cd frontend && npm run lint
+
+      - name: Run build
+        run: cd frontend && npm run build


### PR DESCRIPTION
## What this PR does
- Adds .github/workflows/ci.yml
- CI runs automatically on every PR to dev or main
- Runs npm lint and npm build on the frontend
- Blocks merge if checks fail

## Related issue
Closes #3

## How to test
1. Open any PR to dev or main
2. Check the Actions tab — CI should run automatically
3. Green checkmark = pass, red cross = fail