### PR TITLE
feat: seller can create their store with onboarding flow

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,14 +2,34 @@ const express = require('express')
 const cors = require('cors')
 require('dotenv').config()
 
+const storeRoutes = require('./routes/store')
+const authRoutes = require('./routes/auth')
+
 const app = express()
 const PORT = process.env.PORT || 5000
 
 app.use(cors())
 app.use(express.json())
 
+// Health check
 app.get('/health', (req, res) => {
     res.json({ status: 'ok', message: 'StoreFront API is running' })
+})
+
+// Routes
+app.use('/api/store', storeRoutes)
+app.use('/api/auth', authRoutes)
+
+// Global error handler
+app.use((err, req, res, next) => {
+    console.error(err.stack)
+    res.status(500).json({
+        error: {
+            code: 'SERVER_ERROR',
+            message: 'Something went wrong',
+            status: 500,
+        },
+    })
 })
 
 app.listen(PORT, () => {

--- a/backend/src/lib/prisma.js
+++ b/backend/src/lib/prisma.js
@@ -1,0 +1,11 @@
+const { PrismaClient } = require('@prisma/client')
+
+const globalForPrisma = globalThis
+
+const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') {
+    globalForPrisma.prisma = prisma
+}
+
+module.exports = prisma

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,33 @@
+const express = require('express')
+const router = express.Router()
+const prisma = require('../lib/prisma')
+
+// POST /api/auth/sync-user
+// Called after Google login to ensure user exists in DB
+router.post('/sync-user', async (req, res) => {
+    try {
+        const { name, email, image } = req.body
+
+        if (!email) {
+            return res.status(400).json({
+                error: { code: 'MISSING_EMAIL', message: 'Email is required', status: 400 },
+            })
+        }
+
+        // Find or create user
+        const user = await prisma.user.upsert({
+            where: { email },
+            update: { name, image },
+            create: { name, email, image },
+        })
+
+        return res.json(user)
+    } catch (error) {
+        console.error('Sync user error:', error)
+        return res.status(500).json({
+            error: { code: 'SERVER_ERROR', message: 'Something went wrong', status: 500 },
+        })
+    }
+})
+
+module.exports = router

--- a/backend/src/routes/store.js
+++ b/backend/src/routes/store.js
@@ -1,0 +1,146 @@
+const express = require('express')
+const router = express.Router()
+const prisma = require('../lib/prisma')
+
+// POST /store — create a new store
+router.post('/', async (req, res) => {
+    try {
+        const { name, slug, description, city, themeColor, userEmail, userName, userImage } = req.body
+
+        // Validate required fields
+        if (!name || !slug || !userEmail) {
+            return res.status(400).json({
+                error: {
+                    code: 'MISSING_FIELDS',
+                    message: 'name, slug and userEmail are required',
+                    status: 400,
+                },
+            })
+        }
+
+        // Validate slug format
+        const slugRegex = /^[a-z0-9-]+$/
+        if (!slugRegex.test(slug)) {
+            return res.status(400).json({
+                error: {
+                    code: 'INVALID_SLUG',
+                    message: 'Slug can only contain lowercase letters, numbers and hyphens',
+                    status: 400,
+                },
+            })
+        }
+
+        // Validate slug length
+        if (slug.length > 50) {
+            return res.status(400).json({
+                error: {
+                    code: 'SLUG_TOO_LONG',
+                    message: 'Slug must be 50 characters or less',
+                    status: 400,
+                },
+            })
+        }
+
+        // Check if slug is already taken
+        const existingStore = await prisma.store.findUnique({
+            where: { slug },
+        })
+
+        if (existingStore) {
+            return res.status(400).json({
+                error: {
+                    code: 'SLUG_TAKEN',
+                    message: 'This store URL is already taken. Please choose another.',
+                    status: 400,
+                },
+            })
+        }
+
+        // Find or create user first (upsert)
+        const user = await prisma.user.upsert({
+            where: { email: userEmail },
+            update: { name: userName, image: userImage },
+            create: { email: userEmail, name: userName, image: userImage },
+        })
+
+        // Check if user already has a store
+        const userStore = await prisma.store.findUnique({
+            where: { userId: user.id },
+        })
+
+        if (userStore) {
+            return res.status(400).json({
+                error: {
+                    code: 'STORE_EXISTS',
+                    message: 'You already have a store',
+                    status: 400,
+                },
+            })
+        }
+
+        // Create the store
+        const store = await prisma.store.create({
+            data: {
+                userId: user.id,
+                name,
+                slug,
+                description: description || null,
+                city: city || null,
+                themeColor: themeColor || '#000000',
+            },
+        })
+
+        return res.status(201).json(store)
+    } catch (error) {
+        console.error('Create store error:', error)
+        return res.status(500).json({
+            error: {
+                code: 'SERVER_ERROR',
+                message: 'Something went wrong',
+                status: 500,
+            },
+        })
+    }
+})
+
+// GET /store/me — get logged-in seller's store
+router.get('/me', async (req, res) => {
+    try {
+        const { userEmail } = req.query
+
+        if (!userEmail) {
+            return res.status(400).json({
+                error: { code: 'MISSING_EMAIL', message: 'userEmail is required', status: 400 },
+            })
+        }
+
+        const user = await prisma.user.findUnique({
+            where: { email: userEmail },
+        })
+
+        if (!user) {
+            return res.status(404).json({
+                error: { code: 'USER_NOT_FOUND', message: 'User not found', status: 404 },
+            })
+        }
+
+        const store = await prisma.store.findUnique({
+            where: { userId: user.id },
+        })
+
+        if (!store) {
+            return res.status(404).json({
+                error: { code: 'STORE_NOT_FOUND', message: 'No store found', status: 404 },
+            })
+        }
+
+        return res.json(store)
+    } catch (error) {
+        console.error('Get store error:', error)
+        return res.status(500).json({
+            error: { code: 'SERVER_ERROR', message: 'Something went wrong', status: 500 },
+        })
+    }
+})
+
+module.exports = router

--- a/frontend/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/app/api/auth/[...nextauth]/route.ts
@@ -12,6 +12,23 @@ const handler = NextAuth({
         signIn: "/login",
     },
     callbacks: {
+        async signIn({ user }) {
+            try {
+                // Sync user to our database
+                await fetch("http://localhost:5000/api/auth/sync-user", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        name: user.name,
+                        email: user.email,
+                        image: user.image,
+                    }),
+                })
+            } catch (error) {
+                console.error("Failed to sync user:", error)
+            }
+            return true
+        },
         async session({ session, token }) {
             return session
         },

--- a/frontend/app/dashboard/onboarding/page.tsx
+++ b/frontend/app/dashboard/onboarding/page.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useState } from "react"
+import { useSession } from "next-auth/react"
+import { useRouter } from "next/navigation"
+
+export default function OnboardingPage() {
+    const { data: session } = useSession()
+    const router = useRouter()
+
+    const [name, setName] = useState("")
+    const [slug, setSlug] = useState("")
+    const [description, setDescription] = useState("")
+    const [city, setCity] = useState("")
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState("")
+
+    // Auto-generate slug from store name
+    const handleNameChange = (value: string) => {
+        setName(value)
+        const generatedSlug = value
+            .toLowerCase()
+            .replace(/\s+/g, "-")
+            .replace(/[^a-z0-9-]/g, "")
+            .slice(0, 50)
+        setSlug(generatedSlug)
+    }
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setError("")
+
+        if (!name || !slug) {
+            setError("Store name and URL are required")
+            return
+        }
+
+        if (!session?.user?.email) {
+            setError("You must be logged in")
+            return
+        }
+
+        setLoading(true)
+
+        try {
+            const res = await fetch("http://localhost:5000/api/store", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    name,
+                    slug,
+                    description,
+                    city,
+                    userEmail: session.user.email,
+                    userName: session.user.name,
+                    userImage: session.user.image,
+                }),
+            })
+
+            const data = await res.json()
+
+            if (!res.ok) {
+                setError(data.error?.message || "Something went wrong")
+                return
+            }
+
+            // Success — redirect to dashboard
+            router.push("/dashboard")
+        } catch (err) {
+            setError("Could not connect to server. Make sure backend is running.")
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    return (
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+            <div className="bg-white border border-gray-200 rounded-xl p-8 w-full max-w-md">
+                <div className="w-9 h-9 bg-blue-100 rounded-lg flex items-center justify-center font-medium text-blue-700 mb-6">
+                    S
+                </div>
+                <h1 className="text-xl font-medium mb-1">Create your store</h1>
+                <p className="text-sm text-gray-500 mb-6">
+                    Set up your store in under 2 minutes
+                </p>
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div>
+                        <label className="text-xs text-gray-500 block mb-1">
+                            Store name <span className="text-red-400">*</span>
+                        </label>
+                        <input
+                            type="text"
+                            value={name}
+                            onChange={(e) => handleNameChange(e.target.value)}
+                            placeholder="Priya's Homemade Bakes"
+                            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-gray-400"
+                        />
+                    </div>
+
+                    <div>
+                        <label className="text-xs text-gray-500 block mb-1">
+                            Store URL <span className="text-red-400">*</span>
+                        </label>
+                        <input
+                            type="text"
+                            value={slug}
+                            onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))}
+                            placeholder="priyas-bakes"
+                            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-gray-400"
+                        />
+                        {slug && (
+                            <p className="text-xs text-blue-600 mt-1">
+                                storefront.app/shop/{slug}
+                            </p>
+                        )}
+                    </div>
+
+                    <div>
+                        <label className="text-xs text-gray-500 block mb-1">
+                            Description
+                        </label>
+                        <textarea
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            placeholder="Tell customers what you sell..."
+                            rows={3}
+                            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-gray-400 resize-none"
+                        />
+                    </div>
+
+                    <div>
+                        <label className="text-xs text-gray-500 block mb-1">City</label>
+                        <input
+                            type="text"
+                            value={city}
+                            onChange={(e) => setCity(e.target.value)}
+                            placeholder="Bangalore"
+                            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-gray-400"
+                        />
+                    </div>
+
+                    {error && (
+                        <p className="text-xs text-red-500 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+                            {error}
+                        </p>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={loading}
+                        className="w-full bg-gray-900 text-white rounded-lg py-2.5 text-sm font-medium hover:bg-gray-700 transition disabled:opacity-50"
+                    >
+                        {loading ? "Creating store..." : "Create store"}
+                    </button>
+                </form>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## What this PR does
- Created POST /api/store endpoint with slug validation
- Created GET /api/store/me endpoint
- Created POST /api/auth/sync-user endpoint
- Added upsert logic — creates User row before Store
- Created /dashboard/onboarding page with store creation form
- Auto-generates slug from store name
- Live slug preview shown below input
- Redirects to /dashboard on success

## Related issue
Closes #8

## How to test
1. Start backend: cd backend && npm run dev
2. Start frontend: cd frontend && npm run dev
3. Visit http://localhost:3000/dashboard/onboarding
4. Fill in store name, slug, description, city
5. Click Create store
6. Should redirect to /dashboard